### PR TITLE
Fix vdeform bound calculation

### DIFF
--- a/Lib/CAT_Warp.c
+++ b/Lib/CAT_Warp.c
@@ -127,8 +127,8 @@ apply_warp(polygons_struct *polygons, polygons_struct *sphere, double *deform,
             if (udeform[p] <= -1.0) udeform[p] += floor(-udeform[p]);
             if (udeform[p] >=  0.5) udeform[p] -= 1.0;
             if (udeform[p] <= -0.5) udeform[p] += 1.0;
-            if (vdeform[p] >=  1.0) vdeform[p] -= floor(udeform[p]);
-            if (vdeform[p] <= -1.0) vdeform[p] += floor(-udeform[p]);
+            if (vdeform[p] >=  1.0) vdeform[p] -= floor(vdeform[p]);
+            if (vdeform[p] <= -1.0) vdeform[p] += floor(-vdeform[p]);
             udeform[p] *= weight;
             vdeform[p] *= weight;
         }


### PR DESCRIPTION
## Summary
- fix wrong variable in warp deformation bound check

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8628fa8c832cb91b4ad02454dd19