### PR TITLE
Fix cross-compiling typo

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
 - remove of outer rim (python?)
 - detect WMHs (python)
-- cross-conpiling issue for linux
+- cross-compiling issue for linux
 - https://github.com/arrayfire/arrayfire


### PR DESCRIPTION
## Summary
- fix typo in `TODO`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e8d9ef00c832cb91b0f01cdd2d31e