### PR TITLE
Move debug globals to source file

### DIFF
--- a/Include/CAT_ConvexHull.h
+++ b/Include/CAT_ConvexHull.h
@@ -10,8 +10,8 @@
 #ifndef _CAT_CONVEXHULL_H_
 #define _CAT_CONVEXHULL_H_
 
-static int dbg = 0;
-static int dbg2 = 0;
+extern int dbg;
+extern int dbg2;
 
 #include  <bicpl.h>
 

--- a/Lib/CAT_ConvexHull.c
+++ b/Lib/CAT_ConvexHull.c
@@ -13,6 +13,10 @@
 
 #include "CAT_ConvexHull.h"
 
+/* debug output flags */
+int dbg = 0;
+int dbg2 = 0;
+
 object_struct **
 surface_get_convex_hull(polygons_struct  *polygons, polygons_struct  *polygons_sphere)
 {


### PR DESCRIPTION
## Summary
- avoid header-level definitions of `dbg` and `dbg2`
- define `dbg` and `dbg2` in `CAT_ConvexHull.c`

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8e41cbd8832cad79608c24f2e445