### PR TITLE
Fix invalid value handling in get_sum_double

### DIFF
--- a/Lib/CAT_Math.c
+++ b/Lib/CAT_Math.c
@@ -380,9 +380,8 @@ double get_sum_double(double *arr, int n, int exclude_zeros)
     
     for (i = 0; i < n; i++) {
         if ((exclude_zeros && arr[i] == 0.0) || isnan(arr[i]) || !isfinite(arr[i]))
-            sum += arr[i];
-        else
-            sum += arr[i];
+            continue;
+        sum += arr[i];
     }
     
     return sum;


### PR DESCRIPTION
## Summary
- skip invalid double values in `get_sum_double`
- attempted to build the project but autoconf tools and dependencies were missing

## Testing
- `./autogen.sh` *(fails: libtoolize not found)*
- `make` in `3rdparty/gifticlib` *(fails: nifti1_io.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e914f5c4c832c95125488b73d0acf