### PR TITLE
Fix variance computation in masked std

### DIFF
--- a/Lib/CAT_Math.c
+++ b/Lib/CAT_Math.c
@@ -615,11 +615,13 @@ double get_masked_std_array_double(double *arr, int n, unsigned char *mask)
     }
     mean = mean / (double)count;
 
+    if (count <= 1) return NAN; // Prevent division by zero
+
     /* Calculate variance */
     for (i = 0; i < n; i++)
         if (!isnan(arr[i]) && isfinite(arr[i]) && ((mask && mask[i] > 0) || !mask))
             variance += pow(arr[i] - mean, 2);
-    variance /= (double)n;
+    variance /= (double)(count - 1);
 
     /* Calculate standard deviation */
     return sqrt(variance);


### PR DESCRIPTION
## Summary
- use count when averaging variance for `get_masked_std_array_double`
- avoid division by zero when only 0 or 1 valid samples are present

## Testing
- `./autogen.sh` *(fails: libtoolize not found)*
- `make` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685e91a1c7bc832c91bec01de761a598