### PR TITLE
Fix configure.ac header check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,6 @@ AC_CHECK_LIB(fftw3,fftw_execute,,AC_MSG_ERROR(The fftw3 library is required.))
 
 AC_CHECK_HEADERS(values.h malloc.h)
 
-AC_CHECK_HEADERS()
 
 AC_CONFIG_FILES([Makefile Progs/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
## Summary
- remove stray empty `AC_CHECK_HEADERS` invocation

## Testing
- `./autogen.sh` *(fails: libtoolize: not found)*
- `./configure` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e91b146b4832c88b83aa215d72239