### PR TITLE
Fix sum function exclusion logic

### DIFF
--- a/tests/math_subset.c
+++ b/tests/math_subset.c
@@ -58,9 +58,9 @@ double get_sum_double(double *arr, int n, int exclude_zeros)
 
     for (i = 0; i < n; i++) {
         if ((exclude_zeros && arr[i] == 0.0) || isnan(arr[i]) || !isfinite(arr[i]))
-            sum += arr[i];
-        else
-            sum += arr[i];
+            continue; // Skip invalid values and optionally zeros
+
+        sum += arr[i];
     }
 
     return sum;

--- a/tests/test_math.c
+++ b/tests/test_math.c
@@ -14,6 +14,12 @@ static void test_get_sum(void) {
     MU_ASSERT("sum should be 6", fabs(s - 6.0) < 1e-6);
 }
 
+static void test_get_sum_exclude_zeros(void) {
+    double arr[] = {1.0, 0.0, 2.0};
+    double s = get_sum_double(arr, 3, 1);
+    MU_ASSERT("sum should be 3 when excluding zeros", fabs(s - 3.0) < 1e-6);
+}
+
 static void test_get_mean(void) {
     double arr[] = {2.0, 4.0, 6.0};
     double m = get_mean_double(arr, 3, 0);
@@ -29,6 +35,7 @@ static void test_get_std(void) {
 int main(void) {
     MU_RUN_TEST(test_get_median);
     MU_RUN_TEST(test_get_sum);
+    MU_RUN_TEST(test_get_sum_exclude_zeros);
     MU_RUN_TEST(test_get_mean);
     MU_RUN_TEST(test_get_std);
     printf("%d tests run, %d failed\n", tests_run, tests_failed);


### PR DESCRIPTION
## Summary
- fix incorrect branching in `get_sum_double`
- add regression test for excluding zero elements

## Testing
- `gcc tests/test_math.c -o tests/test_math -lm`
- `./tests/test_math`


------
https://chatgpt.com/codex/tasks/task_e_685e952d5fe0832c905d8b91fa5cd141