### PR TITLE
Remove duplicate function prototype

### DIFF
--- a/Include/CAT_Math.h
+++ b/Include/CAT_Math.h
@@ -74,7 +74,6 @@ double get_mean(void *arr, int n, int mask_zeros, int datatype);
 double get_median(void *arr, int n, int mask_zeros, int datatype);
 double get_std(void *arr, int n, int mask_zeros, int datatype);
 double get_sum(void *arr, int n, int mask_zeros, int datatype);
-double get_mean(void *arr, int n, int mask_zeros, int datatype);
 double get_masked_mean_array(void *arr, int n, unsigned char *mask, int datatype);
 double get_masked_std_array(void *arr, int n, unsigned char *mask, int datatype);
 void get_prctile(void *data, int n, double threshold[2], double prctile[2], int exclude_zeros, int datatype);


### PR DESCRIPTION
## Summary
- clean up header by removing duplicate `get_mean` declaration

## Testing
- `gcc tests/test_math.c -o tests/test_math -lm && ./tests/test_math`


------
https://chatgpt.com/codex/tasks/task_e_685e97ee3b84832c9db0533585e241ca