### PR TITLE
Support external binary GIFTI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Below is a summary of the available command-line programs in CAT-Surface, each d
 | **CAT_Surf2Sheet**          | Flattens surface data (e.g., curvature, morphometry) onto a 2D sheet (PGM image), for visualization or further analysis. |
 | **CAT_Surf2Sphere**         | Inflates a cortical surface mesh onto a sphere using the Caret/Van Essen inflation approach. |
 
+### External binary GIFTI files
+
+Specifying an output name with the `.dat` extension causes CAT-Surface to write
+a `.gii` header alongside a `.dat` binary. The header uses the GIFTI
+`ExternalFileBinary` encoding so the resulting pair is compatible with SPM12.
+
 ## Continuous Integration
 
 A GitHub Actions workflow located in `.github/workflows/ci.yml` automatically


### PR DESCRIPTION
## Summary
- allow saving GIFTI data as external binary via `.dat` extension
- update wrappers to recognise `.dat` files
- document external binary behaviour in README

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_6882b7b8ec94832c9069cd1940abb23c